### PR TITLE
Set mappings of elastisearch to work with dini kim lrmi profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ named as `private.pem` and `public.pem`.
 
 [^1]: Actor names are considered relative to the hostname of the server.
 
-# elasticsearch
+## elasticsearch
 You need to run a properly configured `elasticsearch` instance by
-setting `cluster.name: skohub`. See the provided [elasticsearch.yml](scripts/etc/elasticsearch/elasticsearch.yml).
+setting `cluster.name: skohub`. See the provided [elasticsearch.yml](scripts/etc/elasticsearch/elasticsearch.yml). Also, in some contexts, it's mandatory to initialize elasticsearch
+with a proper [index-mapping](scripts/elasticsearch-mappings.json).
+
+## start scripts
+You may want to use the start script in `scripts/start.sh`. This script ensures the proper
+installation of skohub-pubsub and the configuration of elasticsearch. There also reside
+further scripts to manage the starting/stopping of the skohub-pubsub via init and to
+monitor the processes with `monit`.

--- a/scripts/elasticsearch-mappings.json
+++ b/scripts/elasticsearch-mappings.json
@@ -1,0 +1,15 @@
+{
+   "mappings" : {
+      "_doc" : {
+         "properties" : {
+            "attachment" : {
+               "properties" : {
+                  "@context" : {
+                     "enabled" : false
+                  }
+               }
+            }
+         }
+      }
+   }
+}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -34,8 +34,8 @@ cd $HOME/git/$NAME/scripts
 ###
 # nothing to change from here
 ###
-# ensure elasticsearch index exists
-curl -XPUT $ES_NODE/skohub
+# ensure elasticsearch index exists and initialize proper mappings
+curl -XPUT $ES_NODE/skohub -H 'Content-Type: application/json' -d "@elasticsearch-mappings.json"
 
 npm install
 # start skohub-pubsub


### PR DESCRIPTION
In JSON-LD an '@context' is used to define semantics of JSON fields. These
definitions can consist of an array with mixed data types. This is invalid
when tried to be indexed into elasticsearch. As a mapping of the index can be
defined to ignore the '@context' field for indexing such an JSON-LD document
can then be loaded into elasticsearch.

The mapping must be set when initializing the index. This is done in the
start script provided by skohub-pubsub.

See https://github.com/hbz/skohub-pubsub/issues/40.